### PR TITLE
chore: Migrate Settings from ApplicationStore to SecureStorage

### DIFF
--- a/src/BudgetBadger.Core/Settings/ISettings.cs
+++ b/src/BudgetBadger.Core/Settings/ISettings.cs
@@ -5,7 +5,9 @@ namespace BudgetBadger.Core.Settings
 {
     public interface ISettings
     {
-        string GetValueOrDefault(string key);
+        Task<string> GetValueOrDefaultAsync(string key);
         Task AddOrUpdateValueAsync(string key, string value);
+        Task RemoveAsync(string key);
+        Task RemoveAllAsync();
     }
 }

--- a/src/BudgetBadger.FileSyncProvider.Dropbox/DropboxFileSyncProvider.cs
+++ b/src/BudgetBadger.FileSyncProvider.Dropbox/DropboxFileSyncProvider.cs
@@ -15,7 +15,6 @@ namespace BudgetBadger.FileSyncProvider.Dropbox
     public class DropboxFileSyncProvider : IFileSyncProvider
     {
         readonly ISettings _settings;
-        string _refreshToken { get => _settings.GetValueOrDefault(DropboxSettings.RefreshToken); }
         readonly string _appKey;
 
         public DropboxFileSyncProvider(ISettings settings, string appKey)
@@ -54,7 +53,8 @@ namespace BudgetBadger.FileSyncProvider.Dropbox
 
             try
             {
-                using (var dbx = new DropboxClient(_refreshToken, _appKey))
+                var refreshToken =  await _settings.GetValueOrDefaultAsync(DropboxSettings.RefreshToken);
+                using (var dbx = new DropboxClient(refreshToken, _appKey))
                 {
                     var folderArgs = new ListFolderArg("", recursive: true);
 
@@ -107,13 +107,14 @@ namespace BudgetBadger.FileSyncProvider.Dropbox
 
             try
             {
+                var refreshToken = await _settings.GetValueOrDefaultAsync(DropboxSettings.RefreshToken);
                 var files = sourceDirectory.GetFiles();
 
                 foreach (var file in files)
                 {
                     using (var fileStream = file.Open())
                     using (var compressedFileStream = Compress(fileStream))    
-                    using (var dbx = new DropboxClient(_refreshToken, _appKey))
+                    using (var dbx = new DropboxClient(refreshToken, _appKey))
                     {
                         if (file.Name.EndsWith(".gz"))
                         {

--- a/src/BudgetBadger.Forms/Enums/AppSettings.cs
+++ b/src/BudgetBadger.Forms/Enums/AppSettings.cs
@@ -12,6 +12,6 @@ namespace BudgetBadger.Forms.Enums
         public static readonly string CleanedUpAccountDebtEnvelopes = "CleanedUpAccountDebtEnvelopes";
         public static readonly string CleanedUpBudgets = "CleanedUpBudgets";
         public static readonly string AppearanceDimensionSize = "AppearanceDimensionSize";
-        public static readonly string CurrentAppVersion = "CurrentAppVersion";
+        public static readonly string AppMigrationVersion = "AppMigrationVersion";
     }
 }

--- a/src/BudgetBadger.Forms/ISyncFactory.cs
+++ b/src/BudgetBadger.Forms/ISyncFactory.cs
@@ -7,10 +7,10 @@ namespace BudgetBadger.Forms
 {
     public interface ISyncFactory
     {
-        ISync GetSyncService();
+        Task<ISync> GetSyncServiceAsync();
 
         Task SetLastSyncDateTime(DateTime dateTime);
-        string GetLastSyncDateTime();
+        Task<string> GetLastSyncDateTimeAsync();
 
         Task<Result> EnableDropboxCloudSync();
         Task DisableDropboxCloudSync();

--- a/src/BudgetBadger.Forms/Settings/AppStoreSettings.cs
+++ b/src/BudgetBadger.Forms/Settings/AppStoreSettings.cs
@@ -30,13 +30,30 @@ namespace BudgetBadger.Forms.Settings
             await AppStore.SavePropertiesAsync();
         }
 
-        public string GetValueOrDefault(string key)
+        public Task<string> GetValueOrDefaultAsync(string key)
         {
             if (AppStore.Properties.ContainsKey(key))
             {
-                return AppStore.Properties[key].ToString();
+                return Task.FromResult(AppStore.Properties[key].ToString());
             }
-            return string.Empty;
+            return Task.FromResult(string.Empty);
+        }
+
+        public async Task RemoveAllAsync()
+        {
+            AppStore.Properties.Clear();
+
+            await AppStore.SavePropertiesAsync();
+        }
+
+        public async Task RemoveAsync(string key)
+        {
+            if (AppStore.Properties.ContainsKey(key))
+            {
+                AppStore.Properties.Remove(key);
+
+                await AppStore.SavePropertiesAsync();
+            }
         }
     }
 }

--- a/src/BudgetBadger.Forms/Settings/SecureStorageSettings.cs
+++ b/src/BudgetBadger.Forms/Settings/SecureStorageSettings.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading.Tasks;
+using BudgetBadger.Core.Settings;
+using Xamarin.Essentials;
+
+namespace BudgetBadger.Forms.Settings
+{
+	public class SecureStorageSettings : ISettings
+	{
+		public SecureStorageSettings()
+		{
+		}
+
+        public async Task AddOrUpdateValueAsync(string key, string value)
+        {
+            try
+            {
+                await SecureStorage.SetAsync(key, value);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        public async Task<string> GetValueOrDefaultAsync(string key)
+        {
+            string value = null;
+
+            try
+            {
+                value = await SecureStorage.GetAsync(key);
+            }
+            catch (Exception)
+            {
+                // set value to null to clear out setting in case of corruption
+                await SecureStorage.SetAsync(key, value);
+            }
+
+            return value;
+        }
+
+        public Task RemoveAllAsync()
+        {
+            SecureStorage.RemoveAll();
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(string key)
+        {
+            SecureStorage.Remove(key);
+            return Task.CompletedTask;
+        }
+    }
+}
+

--- a/src/BudgetBadger.Forms/StaticSyncFactory.cs
+++ b/src/BudgetBadger.Forms/StaticSyncFactory.cs
@@ -13,15 +13,16 @@ namespace BudgetBadger.Forms
 {
     public static class StaticSyncFactory
     {
-        public static ISync CreateSync(ISettings settings,
-                                       IDirectoryInfo syncDirectory,
-                                       IAccountSyncLogic accountSyncLogic,
-                                       IPayeeSyncLogic payeeSyncLogic,
-                                       IEnvelopeSyncLogic envelopeSyncLogic,
-                                       ITransactionSyncLogic transactionSyncLogic,
-                                       KeyValuePair<string, IFileSyncProvider>[] fileSyncProviders)
+        public static async Task<ISync> CreateSyncAsync(ISettings settings,
+                                                        IDirectoryInfo syncDirectory,
+                                                        IAccountSyncLogic accountSyncLogic,
+                                                        IPayeeSyncLogic payeeSyncLogic,
+                                                        IEnvelopeSyncLogic envelopeSyncLogic,
+                                                        ITransactionSyncLogic transactionSyncLogic,
+                                                        KeyValuePair<string, IFileSyncProvider>[] fileSyncProviders)
         {
-            if (settings.GetValueOrDefault(AppSettings.SyncMode) == SyncMode.DropboxSync)
+            var syncMode = await settings.GetValueOrDefaultAsync(AppSettings.SyncMode);
+            if (syncMode == SyncMode.DropboxSync)
             {
                 var dropboxFileSyncProvider = fileSyncProviders.FirstOrDefault(f => f.Key == SyncMode.DropboxSync).Value;
 

--- a/src/BudgetBadger.Forms/SyncFactory.cs
+++ b/src/BudgetBadger.Forms/SyncFactory.cs
@@ -51,9 +51,9 @@ namespace BudgetBadger.Forms
             _dialogService = pageDialogService;
         }
 
-        public ISync GetSyncService()
+        public async Task<ISync> GetSyncServiceAsync()
         {
-            return StaticSyncFactory.CreateSync(_settings, _syncDirectory, _accountSyncLogic, _payeeSyncLogic, _envelopeSyncLogic, _transactionSyncLogic, _fileSyncProviders);
+            return await StaticSyncFactory.CreateSyncAsync(_settings, _syncDirectory, _accountSyncLogic, _payeeSyncLogic, _envelopeSyncLogic, _transactionSyncLogic, _fileSyncProviders);
         }
 
         public async Task SetLastSyncDateTime(DateTime dateTime)
@@ -61,15 +61,16 @@ namespace BudgetBadger.Forms
             await _settings.AddOrUpdateValueAsync(AppSettings.LastSyncDateTime, dateTime.ToString());
         }
 
-        public string GetLastSyncDateTime()
+        public async Task<string> GetLastSyncDateTimeAsync()
         {
-            var syncMode = _settings.GetValueOrDefault(AppSettings.SyncMode);
+            var syncMode = await _settings.GetValueOrDefaultAsync(AppSettings.SyncMode);
             if (String.IsNullOrEmpty(syncMode) || syncMode == SyncMode.NoSync)
             {
                 return _resourceContainer.GetResourceString("SyncDateTimeNever");
             }
 
-            if (DateTime.TryParse(_settings.GetValueOrDefault(AppSettings.LastSyncDateTime), out DateTime dateTime))
+            var lastSyncString = await _settings.GetValueOrDefaultAsync(AppSettings.LastSyncDateTime);
+            if (DateTime.TryParse(lastSyncString, out DateTime dateTime))
             {
                 return _resourceContainer.GetFormattedString("{0:g}", dateTime);
             }

--- a/src/BudgetBadger.iOS/BudgetBadger.iOS.csproj
+++ b/src/BudgetBadger.iOS/BudgetBadger.iOS.csproj
@@ -26,8 +26,9 @@
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
-    <CodesignKey>iPhone Developer: Matthew Pritchett (4ZF68XBVNY)</CodesignKey>
+    <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignProvision>Automatic</CodesignProvision>
+    <CodesignEntitlements>SimulatorEntitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -42,6 +43,7 @@
     <CodesignProvision>Automatic</CodesignProvision>
     <MtouchUseLlvm>true</MtouchUseLlvm>
     <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
+    <CodesignEntitlements>SimulatorEntitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,8 +58,8 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <MtouchLink>SdkOnly</MtouchLink>
-    <CodesignProvision></CodesignProvision>
+    <MtouchLink>None</MtouchLink>
+    <CodesignProvision>Automatic</CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -92,6 +94,7 @@
     <Compile Include="Renderers\CurrencyCalculatorRenderer.cs" />
     <Compile Include="Renderers\SwipeBackPageRenderer.cs" />
     <Compile Include="Renderers\DatePickerRenderer.cs" />
+    <None Include="SimulatorEntitlements.plist" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\Contents.json">

--- a/src/BudgetBadger.iOS/SimulatorEntitlements.plist
+++ b/src/BudgetBadger.iOS/SimulatorEntitlements.plist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>keychain-access-groups</key>
+	<array/>
+</dict>
 </plist>


### PR DESCRIPTION
## Description

Switched from using the Prism ApplicationStore to Xamarin.Essentials SecureStorage for saving settings and preferences.

## Related Issue(s)

#51 

## How Has This Been Tested?

Tested on macOS and iOS simulator that it properly migrated settings and no exceptions were thrown when saving and getting settings.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

