### PR TITLE
fix: Fixed crash when changing months and no envelopes created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
   build_sign_android:
     needs: create_version_tag
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
       - name: Setup .NET 6.0.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,10 @@
 ﻿name: test
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   verify_android:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
       - name: Setup .NET 6.0.x

--- a/src/BudgetBadger.Models/ObservableList.cs
+++ b/src/BudgetBadger.Models/ObservableList.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 
 namespace BudgetBadger.Models
 {
@@ -114,7 +115,18 @@ namespace BudgetBadger.Models
         /// </summary> 
         public void RemoveAll()
         {
-            RemoveRange(Items);
+            CheckReentrancy();
+
+            var previouslyEmpty = Items.Count == 0;
+
+            Items.Clear();
+
+            var currentlyEmpty = Items.Count == 0;
+
+            if (previouslyEmpty && currentlyEmpty)
+                return;
+
+            RaiseChangeNotificationEvents(action: NotifyCollectionChangedAction.Reset);
         }
 
         /// <summary> 


### PR DESCRIPTION
## Description

Was iterating over the collection when removing items which caused a crash in a rare scenario of no user envelopes created but debt ones had been.

## Related Issue(s)

Fixes #84 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified in iOS simulator

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots (if appropriate):
